### PR TITLE
Create Pico W project scaffold, add keypad-to-LED firmware and documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.13)
+project(pico_w_keypad_led_controller C CXX)
+
+# Documentation-oriented scaffold:
+# The current firmware source (src/main.cpp) is Arduino-style and depends on <Keypad.h>.
+# Build/run it with the Arduino core for RP2040 (or Wokwi Arduino project mode).
+# This CMakeLists.txt is included to provide a clean C/C++ repository layout.
+
+add_custom_target(info ALL
+  COMMAND ${CMAKE_COMMAND} -E echo "Use Arduino IDE or Wokwi Arduino mode to build src/main.cpp"
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,104 @@
+# Raspberry Pi Pico W Keypad-to-LED Controller
+
+Firmware project for **Raspberry Pi Pico W (RP2040)** that reads a **4x4 matrix keypad** and drives **12 LEDs**.
+
+> The provided source is Arduino-style C++ (`setup()`/`loop()`, `Keypad.h`) and behavior is preserved as-is.
+
+## Features
+
+- 4x4 keypad scanning via the `Keypad` library
+- Individual LED activation for keys `1..8` and `A..D`
+- Group ON/OFF controls:
+  - `9`: turn ON LEDs 1..8
+  - `0`: turn OFF LEDs 1..8
+  - `*`: turn ON LEDs A..D
+  - `#`: turn OFF LEDs A..D
+- Fast polling loop (`delay(10)`) for responsive key handling
+
+## Repository Structure
+
+- `src/main.cpp` - Main firmware logic (unchanged behavior)
+- `include/` - Reserved for headers as the project grows
+- `docs/wiring.md` - Wiring and GPIO map
+- `docs/architecture.md` - Firmware architecture and module notes
+- `CMakeLists.txt` - Lightweight C/C++ repository scaffold
+
+## Components (from `diagram.json`)
+
+- 1x Raspberry Pi Pico / Pico W form-factor board
+- 1x 4x4 membrane keypad
+- 12x LEDs
+  - 8 blue (numeric group)
+  - 4 red (A/B/C/D group)
+- 12x LED series resistors (220Ω)
+- 4x keypad row pull-up resistors (1kΩ tied to 3V3)
+- Shared GND wiring for all LED cathodes
+
+## GPIO Mapping Summary
+
+### Keypad
+
+| Keypad Signal | Pico GPIO |
+|---|---|
+| C1 | GP19 |
+| C2 | GP18 |
+| C3 | GP17 |
+| C4 | GP16 |
+| R1 | GP26 |
+| R2 | GP22 |
+| R3 | GP21 |
+| R4 | GP20 |
+
+### LEDs
+
+| LED Label | Pico GPIO |
+|---|---|
+| 1 | GP11 |
+| 2 | GP10 |
+| 3 | GP9 |
+| 4 | GP8 |
+| 5 | GP7 |
+| 6 | GP6 |
+| 7 | GP5 |
+| 8 | GP4 |
+| A | GP3 |
+| B | GP2 |
+| C | GP28 |
+| D | GP27 |
+
+See full details in [docs/wiring.md](docs/wiring.md).
+
+## Run in Wokwi
+
+1. Create/open a Pico project in Wokwi.
+2. Use the provided `diagram.json` wiring.
+3. Paste `src/main.cpp` into the firmware source (Arduino mode).
+4. Ensure the `Keypad` library is available in the simulation environment.
+5. Start simulation and press keypad buttons to observe LED behavior.
+
+## Run on Real Hardware (Pico W)
+
+### Arduino IDE (recommended for this source)
+
+1. Install **Arduino IDE 2.x**.
+2. Install board package: **Raspberry Pi Pico/RP2040**.
+3. Select board: **Raspberry Pi Pico W**.
+4. Install library: **Keypad** (Library Manager).
+5. Open `src/main.cpp` content in a sketch and upload.
+6. Wire hardware exactly as in `docs/wiring.md`.
+
+### Pico SDK note
+
+This source is not written in Pico SDK style (`pico/stdlib.h` etc.).
+To use Pico SDK directly, a port would be required; this repository intentionally avoids logic changes.
+
+## Wi-Fi / Credentials
+
+- No Wi-Fi APIs are used in current firmware.
+- No credentials are required or stored.
+- If Wi-Fi is added later, keep credentials in a separate non-versioned config file.
+
+## Assumptions
+
+- Wiring and key behavior are inferred from the supplied source arrays and `diagram.json` netlist.
+- LED labels in Wokwi are treated as functional names tied to GPIO mapping.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,51 @@
+# Firmware Architecture
+
+## Overview
+
+The firmware is a single-module Arduino-style C++ program in `src/main.cpp`.
+Core behavior is event-like polling:
+
+1. Initialize all LED GPIOs as outputs and force LOW at startup.
+2. Poll keypad continuously.
+3. On valid key press, dispatch action via `switch` statement.
+4. Delay 10ms and repeat.
+
+## Static Configuration
+
+- `LEDS = 12`, `ROWS = 4`, `COLS = 4`
+- `keys[4][4]`: keypad layout character map
+- `ledPins[12]`: GPIO order for LED control
+- `rowPins[4]`, `colPins[4]`: keypad matrix GPIO assignment
+
+## Initialization Path
+
+### `setup()`
+- Iterates all 12 LED pins
+- Sets each pin to OUTPUT
+- Writes LOW to ensure all LEDs are off at reset
+
+## Runtime Path
+
+### `loop()`
+- Calls `keypad.getKey()`
+- Ignores `NO_KEY`
+- For valid keys:
+  - Numeric `1..8`: turn ON corresponding numeric LED
+  - `9`: turn ON all numeric LEDs (indices 0..7)
+  - `0`: turn OFF all numeric LEDs (indices 0..7)
+  - `A..D`: turn ON corresponding alpha LED
+  - `*`: turn ON all alpha LEDs (indices 8..11)
+  - `#`: turn OFF all alpha LEDs (indices 8..11)
+- Waits `delay(10)`
+
+## Behavior Notes
+
+- LEDs are latched by software state via GPIO writes.
+- No debounce logic beyond loop cadence and library behavior.
+- No Wi-Fi, no interrupts, no dynamic allocation.
+
+## Extension Points (without altering current logic)
+
+- Move pin/key mappings to a header in `include/`.
+- Add optional serial diagnostics around key events.
+- Add explicit “all off” key mapping if desired.

--- a/docs/wiring.md
+++ b/docs/wiring.md
@@ -1,0 +1,57 @@
+# Wiring Reference (Raspberry Pi Pico W)
+
+This document maps the supplied Wokwi `diagram.json` connections to Pico W GPIO usage.
+
+## 1) Keypad Connections (4x4 matrix)
+
+### Columns
+- C1 -> GP19
+- C2 -> GP18
+- C3 -> GP17
+- C4 -> GP16
+
+### Rows
+- R1 -> GP26
+- R2 -> GP22
+- R3 -> GP21
+- R4 -> GP20
+
+### Pull-up network
+Each row is also connected through a 1k resistor to 3V3:
+- R1 via `rp1` (1k)
+- R2 via `rp2` (1k)
+- R3 via `rp4` (1k)
+- R4 via `rp3` (1k)
+
+## 2) LED Connections
+
+All LED cathodes (C) are tied to Pico GND.
+Each LED anode (A) is connected to a GPIO through a 220Ω resistor.
+
+| LED | GPIO | Resistor |
+|---|---|---|
+| 1 | GP11 | r8 (220Ω) |
+| 2 | GP10 | r7 (220Ω) |
+| 3 | GP9 | r6 (220Ω) |
+| 4 | GP8 | r5 (220Ω) |
+| 5 | GP7 | r4 (220Ω) |
+| 6 | GP6 | r3 (220Ω) |
+| 7 | GP5 | r2 (220Ω) |
+| 8 | GP4 | r1 (220Ω) |
+| A | GP3 | r9 (220Ω) |
+| B | GP2 | r10 (220Ω) |
+| C | GP28 | r11 (220Ω) |
+| D | GP27 | r12 (220Ω) |
+
+## 3) UART in Wokwi
+
+- GP0 -> Serial monitor RX
+- GP1 -> Serial monitor TX
+
+No serial output is used in the current firmware, but wiring exists in the diagram.
+
+## 4) Practical Hardware Notes
+
+- Keep a common ground between Pico W and all LED/keypad circuits.
+- 220Ω LED resistors are safe for indicator brightness/current limiting.
+- The 1k pull-ups on keypad rows are present in the original design and preserved here.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,81 @@
+#include <Keypad.h>
+
+const uint8_t LEDS = 12;
+const uint8_t ROWS = 4;
+const uint8_t COLS = 4;
+
+char keys[ROWS][COLS] = {
+  { '1', '2', '3', 'A' },
+  { '4', '5', '6', 'B' },
+  { '7', '8', '9', 'C' },
+  { '*', '0', '#', 'D' }
+};
+
+// Pins connected to LED1, LED2, LED3, ...LED12
+uint8_t ledPins[LEDS] = { 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 28, 27 };
+uint8_t rowPins[ROWS] = { 26, 22, 21, 20 }; // Pins connected to R1, R2, R3, R4
+uint8_t colPins[COLS] = { 19, 18, 17, 16 }; // Pins connected to C1, C2, C3, C4
+
+Keypad keypad = Keypad(makeKeymap(keys), rowPins, colPins, ROWS, COLS);
+
+void setup() {
+  for (uint8_t l = 0; l < LEDS; l++) {
+    pinMode(ledPins[l], OUTPUT);
+    digitalWrite(ledPins[l], LOW);
+  }
+}
+
+void loop() {
+  char key = keypad.getKey();
+
+  if (key != NO_KEY) {
+    switch (key) {
+      case '1': digitalWrite(ledPins[0], HIGH);
+        break;
+      case '2': digitalWrite(ledPins[1], HIGH);
+        break;
+      case '3': digitalWrite(ledPins[2], HIGH);
+        break;
+      case '4': digitalWrite(ledPins[3], HIGH);
+        break;
+      case '5': digitalWrite(ledPins[4], HIGH);
+        break;
+      case '6': digitalWrite(ledPins[5], HIGH);
+        break;
+      case '7': digitalWrite(ledPins[6], HIGH);
+        break;
+      case '8': digitalWrite(ledPins[7], HIGH);
+        break;
+      case '9':
+        for (uint8_t l = 0; l < 8; l++) {
+          digitalWrite(ledPins[l], HIGH);
+        }
+        break;
+      case '0':
+        for (uint8_t l = 0; l < 8; l++) {
+          digitalWrite(ledPins[l], LOW);
+        }
+        break;
+      case 'A': digitalWrite(ledPins[8], HIGH);
+        break;
+      case 'B': digitalWrite(ledPins[9], HIGH);
+        break;
+      case 'C': digitalWrite(ledPins[10], HIGH);
+        break;
+      case 'D': digitalWrite(ledPins[11], HIGH);
+        break;
+      case '*':
+        for (uint8_t l = 8; l < 12; l++) {
+          digitalWrite(ledPins[l], HIGH);
+        }
+        break;
+      case '#':
+        for (uint8_t l = 8; l < 12; l++) {
+          digitalWrite(ledPins[l], LOW);
+        }
+        break;
+    }
+  }
+
+  delay(10);
+}


### PR DESCRIPTION
### Motivation

- Provide a clean, well-structured repository layout for the Raspberry Pi Pico W project and produce comprehensive documentation derived from the supplied source and Wokwi diagram. 
- Preserve the original firmware behavior while making the project easy to run in Wokwi or port to an Arduino/Pico workflow.

### Description

- Added an Arduino-style firmware source at `src/main.cpp` containing the supplied keypad-to-LED logic with identical key map, GPIO arrays, and switch behavior. 
- Added a lightweight project scaffold `CMakeLists.txt` and reserved `include/` for future headers without changing runtime behavior. 
- Created `README.md` with project overview, features, component list (derived from `diagram.json`), GPIO pin mapping, Wokwi instructions, and real-hardware flashing guidance for Pico W. 
- Added `docs/wiring.md` (detailed wiring and resistor mapping) and `docs/architecture.md` (initialization, runtime flow, and extension points) while documenting assumptions and no-secret policy.

### Testing

- Verified repository layout and presence of new files using `find . -maxdepth 3 -type f | sort`, which showed the expected files and paths. 
- Inspected the contents of `src/main.cpp`, `README.md`, `docs/wiring.md`, and `docs/architecture.md` with `nl -ba`/`sed` to confirm documentation accuracy and that firmware logic is unchanged. 
- No compilation or hardware runtime tests were executed in this environment because the source targets the Arduino-style RP2040 flow (Wokwi/Arduino core); instructions for running in Wokwi and on real hardware are included in `README.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29e4f645883328b830ab80793929f)